### PR TITLE
fix: add harbor v2.11.x to known constraints dekn#8409

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,7 @@ func init() { //nolint:gochecknoinits
 		"~2.5.x",
 		"~2.6.x",
 		"~2.10.x",
+		"~2.11.x",
 	)
 }
 


### PR DESCRIPTION
See https://github.com/plotly/dekn/issues/8409

This PR adds the v2.11.x version support to the harbor-operator. It is required for the buildstack operator to use these versions.

```
2024-06-26T10:34:16-04:00	INFO	Need to update DB
2024-06-26T10:34:16-04:00	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
49.30 MiB / 49.30 MiB [-------------------------------------------] 100.00% 17.15 MiB p/s 3.1s
2024-06-26T10:34:20-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T10:34:23-04:00	INFO	Detected OS	family="photon" version="5.0"
2024-06-26T10:34:23-04:00	WARN	This OS version is not on the EOL list	family="photon" version="5.0"
2024-06-26T10:34:23-04:00	INFO	[photon] Detecting vulnerabilities...	os_version="5.0" pkg_num=45

ghcr.io/goharbor/harbor-core:v2.11.0 (photon 5.0)

Total: 0 (HIGH: 0, CRITICAL: 0)
```