### PR TITLE
fix: add harbor v2.12.x to known constraints dekn#10075

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,6 +23,7 @@ func init() { //nolint:gochecknoinits
 		"~2.6.x",
 		"~2.10.x",
 		"~2.11.x",
+		"~2.12.x",
 	)
 }
 


### PR DESCRIPTION
See https://github.com/plotly/dekn/issues/10075

Allows for v2.12.x to be supported by the operator